### PR TITLE
Fix guaranteed assert in Screen._bind() caused by variable shadowing

### DIFF
--- a/lib/src/user_interface.dart
+++ b/lib/src/user_interface.dart
@@ -123,7 +123,7 @@ class Screen {
 
   /// Binds this screen to [ui].
   void _bind(UserInterface ui) {
-    assert(ui == null);
+    assert(_ui == null);
     _ui = ui;
   }
 


### PR DESCRIPTION
This line always asserts without the fix (even happens in hauberk!).
